### PR TITLE
a11y: improvements in french after testing in VO (MacOS+IOS), Orca, O…

### DIFF
--- a/static/i18n/fr-FR/messages.json
+++ b/static/i18n/fr-FR/messages.json
@@ -4,7 +4,7 @@
   "time": "13 Juin 2018",
   "toggle": {
     "stateClosed": "Ouvrir le menu sur sa gauche",
-    "stateOpened": "Fermer le menu"
+    "stateOpened": "Refermer le menu"
   },
   "linkMenu1": {
     "id": "museum-menu-item-1",
@@ -33,10 +33,14 @@
     "link": "https://github.com/jasig/uPortal",
     "name": "Github : uPortal"
   },
-  "List": [{ "tag": "Open Source" }, { "tag": "Apereo" }, { "tag": "Portail" }],
+  "List": [
+    { "tag": "Open Source" },
+    { "tag": "Apereo" },
+    { "tag": "Portail Web" }
+  ],
   "paragraphs": [
     {
-      "para": "<a href='http://www.apereo.org/uportal' rel='noreferrer noopener' target='_blank'>uPortal</a> est une plateforme de portail web Java gratuite et opensource, développée et maintenue par des personnels de l'Enseignement Supérieur sous la coordination de la Fondation <a href='http://www.apereo.org/' rel='noreferrer noopener' target='_blank'>Apereo</a>. uPortal peut agréger du contenu, présenter des applications en libre-service, personnaliser la présentation et le contenu en fonction des groupes et des attributs utilisateur, piloter des applications pour appareils mobiles et permettre une personnalisation avancée et participative de l'expérience du portail. uPortal prend en charge la spécification de portlet Java JSR-286 et JSR-168 pour inclure vos applications personnalisées dans le portail."
+      "para": "<a href='http://www.apereo.org/uportal' rel='noreferrer noopener' target='_blank'>uPortal</a> est une plateforme de portail web Java gratuite et open source, développée et maintenue par des personnels de l’Enseignement Supérieur sous la coordination de la Fondation <a href='http://www.apereo.org/' rel='noreferrer noopener' target='_blank'>Apereo</a>. uPortal peut agréger du contenu, présenter des applications en libre-service, personnaliser la présentation et le contenu en fonction des groupes et des attributs d’un utilisateur, piloter des applications pour des appareils mobiles et permettre une personnalisation avancée et participative de l’expérience du portail. uPortal prend en charge la spécification de portlet Java JSR-286 et JSR-168 pour inclure vos applications personnalisées dans le portail."
     },
     { "para": "Bienvenue sur uPortal." }
   ],
@@ -45,8 +49,8 @@
     "cssClass": "btn btn-default btn-lg",
     "glyphicon": "brands/github.svg",
     "iconColor": "icon-black",
-    "label": "Aller sur les sources Github",
-    "link": "https://github.com/jasig/uportal-start",
+    "label": "Aller sur Github sur l’outil en ligne de commande pour déployer uPortal",
+    "link": "https://github.com/Jasig/uPortal-start/blob/master/LISEZMOI.md",
     "name": "uPortal-Start"
   },
   "button2": {


### PR DESCRIPTION
…ld google talkback

<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the Project Github issue tracker

-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Improvement in issue/feat. n°#4 <!-- add #theNumberInGithubIssue -->
- [x] tests has been done on VoiceOver (VO) in IOS 12.1.4 and MacOS Sierra, Orca in CentOS, Google TalkBack in Android [_not Android Accessibility Suite_]
- [x] existing message properties have been updated with new phrases
- [x] improvement to make view conforms with [wcag 2.1 aa][]

##### Description of change
- Now, someone who speaks French can hear satisfying French with various voice assistance technologies, without surprising accents making the content difficult to understand and making it more perceivable, understandable and predictable.
- added the apostrophe symbol `"’"` used in French.
- the uPortal-Start link goes to the uPortal-Start README in french (LISEZMOI.md)
- Things to be noticed
as a simple example among others (if my memories of VO in Sierra from a few weeks ago are accurate): 
Despite the attribute `lang="fr-FR"`, « opensource » (in French) is pronounced with an English Accent in VoiceOver in MacOS Sierra, whereas « open source » is correctly pronounced in VoiceOver in MacOS Sierra... 
_Implementation Heuristics at the time of Sierra_
réf: [wcag 2.1 aa][]

<!-- Reference Links -->

[wcag 2.1 aa]: https://www.w3.org/TR/WCAG21/
