### PR TITLE
fix(style + a11y): provide layouts examples in CSS flex and CSS Grid

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,13 @@ Apache-2.0
 
 ![Card webcomponent](doc/images/2018-12-08_15-15-58.gif "uPortal card in en-US, fr-FR, es-ES, it, nl-NL")
 
+## See multiple components in Flexbox and Grid layouts
+
+- `Flexbox layout` :eyes: See it in [flexbox layout](https://uportal-contrib.github.io/CardWebComponents/index_albatros)
+- `Grid layout` . :eyes: See it in [a grid layout](https://uportal-contrib.github.io/CardWebComponents/index_grid-labs)
+
+Many Thanks to Heydonworks and Jen Simmons fantastic works
+
 ## Features
 
 - [x] WCAG 2.1 Level AA - Level AAA Work in progress to got beyond simple conformance, but effective Inclusivity,

--- a/static/index_albatros.html
+++ b/static/index_albatros.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="en-US" >
+
+  <head>
+    <meta charset="UTF-8">
+    <title>Flexbox One Column Switch (Any # Of Columns) with The "CardWebComponent" Web Component test page for uPortal</title>
+
+    <meta charset="utf-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
+    <meta name="apple-mobile-web-app-capable" content="yes"/>
+    <meta name="apple-mobile-web-app-status-bar-style" content="black"/>
+    <meta name="description" content="POC webcomponents"/>
+    <link rel="preload" href="https://cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/1.2.0/webcomponents-lite.js" as="script">
+    <link rel="preload" href="https://unpkg.com/regenerator-runtime@0.12.1/runtime.js" as="script">
+    <link rel="preload" href="my-card.umd.js" as="script">
+    <!-- Latest compiled and minified CSS -->
+
+
+
+    <link rel="stylesheet" href="css/style.css">
+
+
+  </head>
+
+  <body>
+    <h1>Flexbox One Column Switch (Any # Of Columns) with The "CardWebComponent" Web Component test page for uPortal</h1>
+
+    <div class="container" role="group" aria-label="Four items at either 25% or 100% width">
+      
+      <div><!-- Beginning of the web component -->
+        <my-card id="what-is-uportal-i18n" messagesPath="./" cssPath="css"></my-card>
+
+        <script src='https://cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/1.2.0/webcomponents-lite.js' defer></script>
+        <script src='https://unpkg.com/regenerator-runtime@0.12.1/runtime.js' defer></script>
+        <script src="my-card.umd.js" defer></script>
+        <!-- End of the web component -->
+      </div>
+      
+      <div>
+        <my-card id="what-is-uportal-i18n-2" messagesPath="./" cssPath="css"></my-card>
+
+        <script src='https://cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/1.2.0/webcomponents-lite.js' defer></script>
+        <script src='https://unpkg.com/regenerator-runtime@0.12.1/runtime.js' defer></script>
+        <script src="my-card.umd.js" defer></script>
+      </div>
+      <div>a0</div>
+      <div>
+        <my-card id="what-is-uportal-i18n-3" messagesPath="./" cssPath="css"></my-card>
+
+        <script src='https://cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/1.2.0/webcomponents-lite.js' defer></script>
+        <script src='https://unpkg.com/regenerator-runtime@0.12.1/runtime.js' defer></script>
+        <script src="my-card.umd.js" defer></script>
+      
+      </div>
+      <div>a</div>
+      <div>b</div>
+      <div>c</div>
+      <div>d</div>
+      <div>
+        <my-card id="what-is-uportal-i18n-4>" messagesPath="./" cssPath="css"></my-card>
+
+        <script src='https://cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/1.2.0/webcomponents-lite.js' defer></script>
+        <script src='https://unpkg.com/regenerator-runtime@0.12.1/runtime.js' defer></script>
+        <script src="my-card.umd.js" defer></script>
+      </div>
+
+      <!-- add more or remove some -->
+    </div>
+  </body>
+
+</html>

--- a/static/index_grid-labs.html
+++ b/static/index_grid-labs.html
@@ -1,0 +1,103 @@
+<!doctype html>
+<html dir="ltr" lang="en-us">
+  <head>
+    <meta charset="UTF-8">
+    <title>CSS Grid example with The "CardWebComponent" Web Component test page for uPortal</title>
+
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>
+    <meta name="apple-mobile-web-app-capable" content="yes"/>
+    <meta name="apple-mobile-web-app-status-bar-style" content="black"/>
+    <meta name="description" content="POC webcomponents"/>
+    
+    <link rel="preload" href="https://cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/1.2.0/webcomponents-lite.js" as="script">
+    <link rel="preload" href="https://unpkg.com/regenerator-runtime@0.12.1/runtime.js" as="script">
+    <link rel="preload" href="my-card.umd.js" as="script">
+    
+    <link rel="stylesheet" href="css/01-009.css">
+  </head>
+  <body class="F index">
+    
+    <h1>CSS Grid example with with The "CardWebComponent" Web Component test page for uPortal</h1>
+
+  <main>
+    <article>
+      <img src="https://s3-us-west-2.amazonaws.com/s.cdpn.io/10558/Paleo_food.jpg">
+      <h2>1) All of These Headlines Are Not Exactly The Same</h2>
+      <p>In the real world, you don't know how long the content will be. Writers will write what they need. Photos will be cropped to the shape that they should be. That's good. Make a system that allows this. You want it to be flexible and robust.</p>
+    </article>
+    <section>
+      <!-- Beginning of the web component -->
+        <my-card id="what-is-uportal-i18n" messagesPath="./" cssPath="css"></my-card>
+
+        <script src='https://cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/1.2.0/webcomponents-lite.js' defer></script>
+        <script src='https://unpkg.com/regenerator-runtime@0.12.1/runtime.js' defer></script>
+        <script src="my-card.umd.js" defer></script>
+        <!-- End of the web component -->
+    </section>
+    <article>    
+      <img src="https://s3-us-west-2.amazonaws.com/s.cdpn.io/10558/Indian_bengali_food.jpg">
+      <h2>2) Some Are Short</h2>
+      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus.</p> 
+    </article>
+    <article>
+      <img src="https://s3-us-west-2.amazonaws.com/s.cdpn.io/10558/Food_in_Miyajima.jpg">
+      <h2>3) Some Headlines Can Sometimes Be Quite Long, Because It Takes Time to Make A Point</h2>
+      <p>Vivamus fermentum semper porta. Nunc diam velit, adipiscing ut tristique vitae, sagittis vel odio. Maecenas convallis ullamcorper ultricies. Curabitur ornare, ligula semper consectetur sagittis, nisi diam iaculis velit, id fringilla sem nunc vel mi. Nam dictum, odio nec pretium volutpat, arcu ante placerat erat, non tristique elit urna et turpis.</p> 
+    </article>
+    <article>
+      <img src="https://s3-us-west-2.amazonaws.com/s.cdpn.io/10558/P1-Food_with_love.jpg">
+      <h2>4) Also, Why Are We Using Fake Content? Let's Make Some Real-ish Content.</h2>
+      <p>By using real content, we can see the variation inherent in what this site might present. And we can design for those real world needs.
+    </article>
+    <section>    
+      <my-card id="what-is-uportal-i18n-3" messagesPath="./" cssPath="css"></my-card>
+
+        <script src='https://cdnjs.cloudflare.com/ajax/libs/webcomponentsjs/1.2.0/webcomponents-lite.js' defer></script>
+        <script src='https://unpkg.com/regenerator-runtime@0.12.1/runtime.js' defer></script>
+        <script src="my-card.umd.js" defer></script> 
+    </section>
+    <article>
+      <img src="https://s3-us-west-2.amazonaws.com/s.cdpn.io/10558/Birds_on_stick_Shanghai_Qibao.jpg">
+      <h2>6) See how this layout is broken?</h2>
+      <p>That's because floats are really crap at handling layout. We've been using a screwdriver as a hammer. It sort of works, but badly.</p> 
+    </article>
+    <article>
+      <img src="https://s3-us-west-2.amazonaws.com/s.cdpn.io/10558/Restaurant_food_Kunming_Yunnan.jpg">
+      <h2>7) The New CSS Will Fix Things</h2>
+      <p>Finally we get some real hammers.</p>
+    </article>
+    <article>    
+      <img src="https://s3-us-west-2.amazonaws.com/s.cdpn.io/10558/Bunter_Teller.jpg">
+      <h2>8) Several Kinds of Hammers</h2>
+      <p>Grid, Flexbox, Alignment, Shapes.</p> 
+    </article>
+    <article>
+      <img src="https://s3-us-west-2.amazonaws.com/s.cdpn.io/10558/P3-Egyptian_food_Koshary.jpg">
+      <h2>9) Size, Isn't That Magical!</h2>
+      <p>Lorem ipsum dolor sit amet.</p> 
+    </article>
+    <article>
+      <img src="https://s3-us-west-2.amazonaws.com/s.cdpn.io/10558/Mexican_food.jpg">
+      <h2>10) All of These Headlines</h2>
+      <p>Always three lines of text, which fits exactly in the available space. Describing where you will go when you click.</p>
+    </article>
+    <article>    
+      <img src="https://s3-us-west-2.amazonaws.com/s.cdpn.io/10558/P2-Arepitas_Food_Macro.jpg">
+      <h2>11) Are Exactly the Same</h2>
+      <p>Vivamus fermentum semper porta. Nunc diam velit, adipiscing ut tristique vitae, sagittis vel odio. Maecenas convallis ullamcorper ultricies. Curabitur ornare, ligula semper consectetur sagittis, nisi diam iaculis velit, id fringilla sem nunc vel mi. </p>     
+    </article>
+    <article>
+      <img src="https://s3-us-west-2.amazonaws.com/s.cdpn.io/10558/Ravenna_food.jpg">
+      <h2>12) Size, Isn't That Magical!</h2>
+      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec a diam lectus. Sed sit amet ipsum mauris tindunt.</p> 
+    </article>
+    
+  </main>
+
+<!-- Gathering lightweight statics via Gaug.es -->
+<script type="text/javascript">var _gauges = _gauges || []; (function() {var t   = document.createElement('script'); t.type  = 'text/javascript'; t.async = true; t.id    = 'gauges-tracker'; t.setAttribute('data-site-id', '59133cdabad3a70724018023'); t.setAttribute('data-track-path', 'https://track.gaug.es/track.gif'); t.src = 'https://d36ee2fcip1434.cloudfront.net/track.js'; var s = document.getElementsByTagName('script')[0]; s.parentNode.insertBefore(t, s);})();</script>
+<!-- end stats -->
+
+  </body>
+</html>

--- a/static/scss/my-card.scss
+++ b/static/scss/my-card.scss
@@ -198,6 +198,8 @@ a:focus-visible {
 }
 
 .card-wrapper {
+  overflow: hidden;
+
   img[src$=".svg"] {
     width: 21px;
     height: 21px;


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the Project Github issue tracker

-->

##### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] add examples test of the components in flexbox layout and grid layout
- [x] doc is changed

##### Description of change
see
 -  [webcomponents in flexbox layout in the holy albatross way (heydonworks)](https://uportal-contrib.github.io/CardWebComponents/index_albatros)
 - [ grid layout with the webcomponents](https://uportal-contrib.github.io/CardWebComponents/index_grid-labs)


<!-- Reference Links -->
[individual contributor license agreement]: https://www.apereo.org/licensing/agreements/icla 
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/.github/CONTRIBUTING.md
[wcag 2.1 aa]: https://www.w3.org/TR/WCAG21/
